### PR TITLE
Fix 'format' for newer biopython versions

### DIFF
--- a/main/modules/ClusterEval.py
+++ b/main/modules/ClusterEval.py
@@ -142,7 +142,7 @@ def _cal_seq_ident(seq_rec_pair_to_align):
     check_count = 0
 
     for seq_align in seq_aligner.align(short_seq, long_seq):
-        seq_align_pattern = format(seq_align, 'fasta').split(os.linesep)[1]
+        seq_align_pattern = format(seq_align).split(os.linesep)[1]
         seq_ident = seq_align_pattern.count('|') / len(seq_align_pattern.strip('-'))
 
         if seq_ident > max_seq_ident:


### PR DESCRIPTION
Hi!

I just found myself facing the same error message that @mmpust describes at #1.

Changes in the last version of Biopython (v1.79) has modified the way the *format* method for a sequence alignment behaves. From now on, the 'fasta' argument is no longer recognized as a valid format and will rise an exception. Some of the documentation is still old, but the [new implementation](https://github.com/biopython/biopython/blob/7992a2fd12e656aa5ef9f879350d361e5e0aefeb/Bio/Align/__init__.py#L1735) can be checked.

Removing the 'fasta' argument will fix this issue. And I have tested that it remains retro-compatible with Biopython v1.78, as it falls-back to 'fasta' when no argument is provided.

